### PR TITLE
add --show-error option

### DIFF
--- a/curl/.curlrc
+++ b/curl/.curlrc
@@ -1,1 +1,1 @@
---silent
+--silent --show-error


### PR DESCRIPTION
extract of curl(1)

-S, --show-error
              When used with -s, --silent, it makes curl show an error message if it fails.